### PR TITLE
[feat] 공통 Heading 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
 import { Outlet } from 'react-router-dom';
 
+import Heading from './common/component/Heading/Heading';
+
 const App = () => {
   return (
     <main>
       <Outlet />
+      <Heading heading="H1">가나다라마바사</Heading>
     </main>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,9 @@
 import { Outlet } from 'react-router-dom';
 
-import Heading from './common/component/Heading/Heading';
-
 const App = () => {
   return (
     <main>
       <Outlet />
-      <Heading heading="H1">가나다라마바사</Heading>
     </main>
   );
 };

--- a/src/common/component/Heading/Heading.tsx
+++ b/src/common/component/Heading/Heading.tsx
@@ -8,7 +8,7 @@ interface HeadingProps extends ComponentPropsWithoutRef<'h3'> {
   heading?: headingType;
 }
 
-const headingTag = {
+const HeadingTag = {
   H1: 'h1',
   H2: 'h2',
   H3: 'h3',
@@ -16,10 +16,10 @@ const headingTag = {
   H5: 'h5',
   H6: 'h6',
   H7: 'h6',
-};
+} as const;
 
 const Heading = ({ heading = 'H3', ...props }: HeadingProps) => {
-  const Tag = headingTag[heading] as React.ElementType;
+  const Tag = HeadingTag[heading];
 
   return (
     <Tag css={headingStyle[heading]} {...props}>

--- a/src/common/component/Heading/Heading.tsx
+++ b/src/common/component/Heading/Heading.tsx
@@ -1,0 +1,31 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+import { headingStyle } from './heading.style';
+
+type headingType = 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'H7';
+
+interface HeadingProps extends ComponentPropsWithoutRef<'h3'> {
+  heading: headingType;
+}
+
+const headingTag = {
+  H1: 'h1',
+  H2: 'h2',
+  H3: 'h3',
+  H4: 'h4',
+  H5: 'h5',
+  H6: 'h6',
+  H7: 'h6',
+};
+
+const Heading = ({ heading = 'H3', ...props }: HeadingProps) => {
+  const Tag = headingTag[heading] as React.ElementType;
+
+  return (
+    <Tag css={headingStyle[heading]} {...props}>
+      {props.children}
+    </Tag>
+  );
+};
+
+export default Heading;

--- a/src/common/component/Heading/Heading.tsx
+++ b/src/common/component/Heading/Heading.tsx
@@ -5,7 +5,7 @@ import { headingStyle } from './heading.style';
 type headingType = 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'H7';
 
 interface HeadingProps extends ComponentPropsWithoutRef<'h3'> {
-  heading: headingType;
+  heading?: headingType;
 }
 
 const headingTag = {

--- a/src/common/component/Heading/Heading.tsx
+++ b/src/common/component/Heading/Heading.tsx
@@ -5,7 +5,7 @@ import { headingStyle } from './heading.style';
 type HeadingType = 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'H7';
 
 interface HeadingProps extends ComponentPropsWithoutRef<'h3'> {
-  heading?: HeadingType;
+  variant?: HeadingType;
 }
 
 const HeadingTag = {
@@ -18,11 +18,11 @@ const HeadingTag = {
   H7: 'h6',
 } as const;
 
-const Heading = ({ heading = 'H3', ...props }: HeadingProps) => {
-  const Tag = HeadingTag[heading];
+const Heading = ({ variant = 'H3', ...props }: HeadingProps) => {
+  const Tag = HeadingTag[variant];
 
   return (
-    <Tag css={headingStyle[heading]} {...props}>
+    <Tag css={headingStyle[variant]} {...props}>
       {props.children}
     </Tag>
   );

--- a/src/common/component/Heading/Heading.tsx
+++ b/src/common/component/Heading/Heading.tsx
@@ -2,10 +2,10 @@ import { ComponentPropsWithoutRef } from 'react';
 
 import { headingStyle } from './heading.style';
 
-type headingType = 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'H7';
+type HeadingType = 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6' | 'H7';
 
 interface HeadingProps extends ComponentPropsWithoutRef<'h3'> {
-  heading?: headingType;
+  heading?: HeadingType;
 }
 
 const HeadingTag = {

--- a/src/common/component/Heading/heading.style.ts
+++ b/src/common/component/Heading/heading.style.ts
@@ -1,0 +1,13 @@
+import { css } from '@emotion/react';
+
+import { theme } from '@/common/style/theme/theme';
+
+export const headingStyle = {
+  H1: css(theme.heading.heading01),
+  H2: css(theme.heading.heading02),
+  H3: css(theme.heading.heading03),
+  H4: css(theme.heading.heading04),
+  H5: css(theme.heading.heading05),
+  H6: css(theme.heading.heading06),
+  H7: css(theme.heading.heading07),
+};

--- a/src/story/Heading.stories.tsx
+++ b/src/story/Heading.stories.tsx
@@ -10,7 +10,6 @@ const meta = {
   },
   args: {
     children: 'Heading',
-    heading: 'H3',
   },
   argTypes: {
     children: {

--- a/src/story/Heading.stories.tsx
+++ b/src/story/Heading.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   },
   args: {
     children: 'Heading',
+    heading: 'H3',
   },
   argTypes: {
     children: {

--- a/src/story/Heading.stories.tsx
+++ b/src/story/Heading.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Heading from '@/common/component/Heading/Heading';
+
+const meta = {
+  title: 'Common/Heading',
+  component: Heading,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    children: 'Heading',
+  },
+  argTypes: {
+    children: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+} satisfies Meta<typeof Heading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #16

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] ✨ 저는 (common)로 분리했어요.

---

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->
---
다형성 컴포넌트에 대해 처음 알게 되었다. 하다가 막혀서 주용썜 코드를 봤는데 본 순간부터 정답을 알게되어서 주용쌤 코드를 공부하는 방향으로 개발을 했습니다. 개발하는 과정을 간단하게 담은 [아티클](https://northern-production-784.notion.site/Heading-3b97098d86d04999988f593c1edd6165?pvs=4)로 알게된 부분은 대체하겠습니다.

반성하겠습니다 commit을 신경을 못썼습니다.. 보통 컴포넌트 단위로 commit을 나누다 보니 commit을 안했는데 다은이꺼 commit을 보니 하나의 컴포넌트를 만들면서도 많은 commit을 하더라고요?? 다음부턴 작은 컴포넌트 만들때도 commit을 더 잘게 나눠서 신경써보겠습니다! 

## 📌사용법
```typescript
import Heading from './common/component/Heading/Heading';

const App = () => {
  return (
    <main>
      <Heading heading="H1">가나다라마바사</Heading>
    </main>
  );
};
```
Heading 컴포넌트에 heading prop을 H1 ~ H7 중  GUI에 적혀있는 값으로 선택해서 사용한다.
H1 ~ H5는 h1 ~ h5에 매칭되고 H6, H7은 h6에 매칭된다.
