### PR TITLE
[Feature] 타임라인 블록 클릭 시 중앙으로 스크롤 구현, 랜딩 페이지 화살표로 뷰 전환 구현

### DIFF
--- a/src/common/asset/svg/arrow_fill.svg
+++ b/src/common/asset/svg/arrow_fill.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="20" viewBox="0 0 40 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3.525 0.737305L20 12.1873L36.475 0.737305L40 4.2623L20 19.2623L0 4.2623L3.525 0.737305Z" fill="#353F9B"/>
+</svg>

--- a/src/page/archiving/index/ArchivingPage.tsx
+++ b/src/page/archiving/index/ArchivingPage.tsx
@@ -38,6 +38,16 @@ const ArchivingPage = () => {
   const handleBlockClick = (e: React.MouseEvent<HTMLDivElement>, block: Block) => {
     e.stopPropagation();
 
+    const clickedBlock = document.getElementById(String(block.timeBlockId));
+
+    if (clickedBlock) {
+      clickedBlock.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'center',
+        block: 'center',
+      });
+    }
+
     setSelectedBlock(block);
     setSelectedId('selected');
   };
@@ -122,6 +132,7 @@ const ArchivingPage = () => {
 
               return (
                 <TimeBlock
+                  id={String(block.timeBlockId)}
                   key={block.timeBlockId}
                   startDate={startDate}
                   endDate={endDate}

--- a/src/page/archiving/index/component/TimeBlock/TimeBlock.tsx
+++ b/src/page/archiving/index/component/TimeBlock/TimeBlock.tsx
@@ -1,9 +1,9 @@
 import { blockStyle, spanStyle } from '@/page/archiving/index/component/TimeBlock/TimeBlock.style';
 import { BLOCK_TYPE } from '@/page/archiving/index/constant/blockIcon';
 
-import React, { ReactNode } from 'react';
+import React, { HTMLAttributes, ReactNode } from 'react';
 
-interface TimeBlockProps {
+interface TimeBlockProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
   startDate: Date;
   endDate: Date;
@@ -23,13 +23,14 @@ const TimeBlock = ({
   onBlockClick,
   isSelected = false,
   blockType,
+  ...props
 }: TimeBlockProps) => {
   const blockWidth = (new Date(endDate).getDate() - new Date(startDate).getDate() + 1) * 6;
   const startPosition = (new Date(startDate).getDate() - 1) * 6;
 
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-    <div css={blockStyle(blockWidth, startPosition, floor, color, isSelected)} onClick={onBlockClick}>
+    <div css={blockStyle(blockWidth, startPosition, floor, color, isSelected)} onClick={onBlockClick} {...props}>
       {BLOCK_TYPE.find((icon) => icon.name === blockType)?.icon}
       <p css={spanStyle}>{children}</p>
     </div>

--- a/src/page/landing/LandingPage.style.ts
+++ b/src/page/landing/LandingPage.style.ts
@@ -106,7 +106,8 @@ export const secondImgWrapperStyle = css({
 
   position: 'absolute',
   right: 0,
-  bottom: '7.4rem',
+
+  bottom: '10.4rem',
 
   width: '70%',
   aspectRatio: '3 / 2',
@@ -120,4 +121,11 @@ export const hideStyle = css({
   /** observe 시 스타일 적용 전 */
   opacity: 0,
   transform: 'translateY(2rem)',
+});
+
+export const arrowStyle = css({
+  position: 'absolute',
+  bottom: '4rem',
+
+  cursor: 'pointer',
 });

--- a/src/page/landing/LandingPage.tsx
+++ b/src/page/landing/LandingPage.tsx
@@ -9,13 +9,13 @@ import {
   textWrapperStyle,
   viewImgStyle,
 } from '@/page/landing/LandingPage.style';
+import Indicator from '@/page/landing/component/Indicator/Indicator';
 import LandingOverview from '@/page/landing/component/Overview/Overview';
 import { TEXT } from '@/page/landing/constant';
 
 import firstView from '@/common/asset/img/landing01.png';
 import secondCharacter from '@/common/asset/img/landing02.png';
 import secondView from '@/common/asset/img/service02.png';
-import ArrowDown from '@/common/asset/svg/arrow-down.svg?react';
 import Button from '@/common/component/Button/Button';
 import Heading from '@/common/component/Heading/Heading';
 import Text from '@/common/component/Text/Text';
@@ -45,6 +45,15 @@ const LandingPage = () => {
 
   const { isLoggedIn } = useStore();
 
+  const 세번째뷰로 = () => {
+    const next = feature1Ref.current;
+
+    next?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  };
+
   const 다음페이지로 = () => {
     window.location.href = isLoggedIn ? PATH.SHOWCASE : PATH.LOGIN;
   };
@@ -59,10 +68,18 @@ const LandingPage = () => {
         <Button onClick={다음페이지로} css={startedButtonStyle} variant="action">
           시작하기
         </Button>
-        <ArrowDown />
+        <Indicator
+          onNext={() => {
+            const next = overviewRef.current;
+            next?.scrollIntoView({
+              behavior: 'smooth',
+              block: 'center',
+            });
+          }}
+        />
       </section>
-      <LandingOverview ref={overviewRef} />
-      <section ref={feature1Ref} css={[featureSectionStyle, { textAlign: 'start' }]}>
+      <LandingOverview onNext={세번째뷰로} ref={overviewRef} />
+      <section ref={feature1Ref} css={[featureSectionStyle, { textAlign: 'start', position: 'relative' }]}>
         <div css={textWrapperStyle}>
           <Heading css={hideStyle} tag="H1">
             {TEXT.FEATURE_HEADING.FIRST}
@@ -74,6 +91,15 @@ const LandingPage = () => {
         <div css={firstImgWrapperStyle}>
           <img css={viewImgStyle} src={firstView} alt="서비스 뷰 1" />
         </div>
+        <Indicator
+          onNext={() => {
+            const next = feature2Ref.current;
+            next?.scrollIntoView({
+              behavior: 'smooth',
+              block: 'center',
+            });
+          }}
+        />
       </section>
       <section ref={feature2Ref} css={[featureSectionStyle, { textAlign: 'start' }]}>
         <div css={textWrapperStyle}>
@@ -89,6 +115,19 @@ const LandingPage = () => {
           <img css={{ width: '30%', height: '30%', placeSelf: 'end' }} src={secondCharacter} alt="티키 캐릭터 2" />
           <img css={viewImgStyle} src={secondView} alt="서비스 뷰 2" />
         </div>
+        <Indicator
+          css={{
+            transform: 'rotateZ(180deg)',
+          }}
+          onNext={() => {
+            const reset = document.querySelector('#landing_view section:nth-child(1)');
+
+            reset?.scrollIntoView({
+              behavior: 'smooth',
+              block: 'center',
+            });
+          }}
+        />
       </section>
     </div>
   );

--- a/src/page/landing/component/Indicator/Indicator.tsx
+++ b/src/page/landing/component/Indicator/Indicator.tsx
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+
+import { ComponentPropsWithoutRef } from 'react';
+
+import ArrowDown from '@/common/asset/svg/arrow_fill.svg?react';
+
+interface IndicatorProps extends ComponentPropsWithoutRef<'svg'> {
+  onNext?: () => void;
+}
+
+const Indicator = ({ onNext, ...props }: IndicatorProps) => {
+  return <ArrowDown css={indicatorStyle} width={36} height={36} onClick={onNext} {...props} />;
+};
+
+export default Indicator;
+
+const indicatorStyle = css({
+  position: 'absolute',
+  bottom: '4rem',
+  left: 0,
+  right: 0,
+
+  margin: '0 auto',
+
+  cursor: 'pointer',
+});

--- a/src/page/landing/component/Overview/Overview.style.ts
+++ b/src/page/landing/component/Overview/Overview.style.ts
@@ -9,6 +9,8 @@ export const containerStyle = css({
   justifyContent: 'center',
   gap: '9.6rem',
 
+  position: 'relative',
+
   padding: '14rem 0',
 
   backgroundColor: theme.colors.blue_900,

--- a/src/page/landing/component/Overview/Overview.tsx
+++ b/src/page/landing/component/Overview/Overview.tsx
@@ -1,3 +1,4 @@
+import Indicator from '@/page/landing/component/Indicator/Indicator';
 import { containerStyle, titleStyle } from '@/page/landing/component/Overview/Overview.style';
 import { TEXT } from '@/page/landing/constant';
 import { css } from '@emotion/react';
@@ -7,14 +8,26 @@ import { ForwardedRef, forwardRef } from 'react';
 
 import serviceAni from '@/common/asset/json/landing_ani.json';
 import Heading from '@/common/component/Heading/Heading';
+import { theme } from '@/common/style/theme/theme';
 
-const Overview = ({}, ref: ForwardedRef<HTMLElement>) => {
+interface OverviewProps {
+  onNext?: () => void;
+}
+const Overview = ({ onNext }: OverviewProps, ref: ForwardedRef<HTMLElement>) => {
   return (
     <section ref={ref} css={containerStyle}>
       <Heading tag="H1" css={titleStyle}>
         {TEXT.OVERVIEW}
       </Heading>
       <Lottie aria-label="서비스 소개 애니메이션" animationData={serviceAni} loop={true} css={animationStyle} />
+      <Indicator
+        onNext={onNext}
+        css={{
+          path: {
+            fill: theme.colors.white,
+          },
+        }}
+      />
     </section>
   );
 };


### PR DESCRIPTION
## 해당 이슈 번호

closed #177 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 📌 내가 알게 된 부분

`scrollIntoView` 메서드를 이용하여 구현하였습니다. `behavior`는 스크롤 움직임 속성을, `block`은 수직 정렬을, `inline`은 수평 정렬을 의미합니다. 기존에 사용해본 적이 있는 기능이였지만, 이번에 다시 찾아보며 구현하면서 다시금 상기시킬 수 있었습니다.

---


## 📌스크린샷 (선택)

https://github.com/user-attachments/assets/92610ef9-c0a4-46ec-9f11-f1e5395bdd81

