### PR TITLE
[Hotfix] 타임라인 scrollIntoView 될 시 부모 요소 스크롤 방지, 현재 날짜 섹션의 dashed line 클릭 이벤트 막기

### DIFF
--- a/src/page/archiving/index/ArchivingPage.tsx
+++ b/src/page/archiving/index/ArchivingPage.tsx
@@ -83,7 +83,7 @@ const ArchivingPage = () => {
         justify: 'center',
         align: 'center',
         width: '100%',
-        height: '100vh',
+        height: '100%',
         paddingLeft: '6rem',
       }}
       css={{ overflowY: 'hidden', overflowX: 'hidden' }}>

--- a/src/page/archiving/index/component/DaySection/DaySection.tsx
+++ b/src/page/archiving/index/component/DaySection/DaySection.tsx
@@ -28,6 +28,8 @@ const DottedDayLine = () => {
         zIndex: theme.zIndex.overlayMiddle,
 
         borderLeft: `1px dashed ${theme.colors.blue_900}`,
+
+        pointerEvents: 'none',
       }}
     />
   );


### PR DESCRIPTION
## 해당 이슈 번호

#165 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

