### PR TITLE
[Feat] 액세스 토큰 없을 시, 리프레시 토큰을 통해 재발급하는 인터셉터 구현 / Public 라우트는 인증 회원에게 방어하지 않도록 수정

### DIFF
--- a/src/common/router/Router.tsx
+++ b/src/common/router/Router.tsx
@@ -8,29 +8,18 @@ import ShowcasePage from '@/page/showcase/index/ShowcasePage';
 import TermPage from '@/page/signUp/index/TermPage';
 import InfoFormPage from '@/page/signUp/info/InfoFormPage';
 
-import { useEffect } from 'react';
 import { Outlet, RouterProvider, createBrowserRouter, useNavigate } from 'react-router-dom';
 
 import ErrorBoundary from '@/common/component/ErrorBoundary/ErrorBoundary';
 
-import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 import ComingsoonPage from '@/shared/page/comingsoonPage/ComingsoonPage';
 import ErrorPage from '@/shared/page/errorPage/ErrorPage';
-import useStore from '@/shared/store/auth';
 
-const NoAuthWrapper = () => {
+const Public = () => {
   const navigate = useNavigate();
 
   const handleReset = () => navigate(-1);
-
-  const { login } = useStore();
-
-  useEffect(() => {
-    if (localStorage.getItem(ACCESS_TOKEN_KEY)) {
-      login();
-    }
-  }, [login]);
 
   return (
     <ErrorBoundary fallback={ErrorPage} onReset={handleReset}>
@@ -42,7 +31,7 @@ const NoAuthWrapper = () => {
 const router = createBrowserRouter([
   {
     path: PATH.ROOT,
-    element: <NoAuthWrapper />,
+    element: <Public />,
     errorElement: <ErrorPage />,
     children: [
       { path: PATH.LANDING, element: <LandingPage /> },
@@ -70,10 +59,6 @@ const router = createBrowserRouter([
         path: PATH.PASSWORD_RESET,
         element: <PasswordResetPage />,
       },
-      {
-        path: PATH.COMING_SOON,
-        element: <ComingsoonPage />,
-      },
     ],
   },
   {
@@ -83,6 +68,10 @@ const router = createBrowserRouter([
     children: [
       { path: PATH.SHOWCASE, element: <ShowcasePage /> },
       { path: PATH.ARCHIVING, element: <ArchivingPage /> },
+      {
+        path: PATH.COMING_SOON,
+        element: <ComingsoonPage />,
+      },
     ],
   },
 ]);

--- a/src/page/archiving/index/ArchivingPage.tsx
+++ b/src/page/archiving/index/ArchivingPage.tsx
@@ -38,15 +38,11 @@ const ArchivingPage = () => {
   const handleBlockClick = (e: React.MouseEvent<HTMLDivElement>, block: Block) => {
     e.stopPropagation();
 
-    const clickedBlock = document.getElementById(String(block.timeBlockId));
-
-    if (clickedBlock) {
-      clickedBlock.scrollIntoView({
-        behavior: 'smooth',
-        inline: 'center',
-        block: 'center',
-      });
-    }
+    e.currentTarget.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'center',
+      block: 'center',
+    });
 
     setSelectedBlock(block);
     setSelectedId('selected');
@@ -132,7 +128,6 @@ const ArchivingPage = () => {
 
               return (
                 <TimeBlock
-                  id={String(block.timeBlockId)}
                   key={block.timeBlockId}
                   startDate={startDate}
                   endDate={endDate}

--- a/src/page/archiving/index/component/DocumentBar/DocumentBar.tsx
+++ b/src/page/archiving/index/component/DocumentBar/DocumentBar.tsx
@@ -39,7 +39,7 @@ const DocumentBar = (
     setSearchWord(e.target.value);
   };
 
-  const { data: blockData } = useBlockQuery(+teamId, selectedBlock?.timeBlockId ?? 69, selectedId);
+  const { data: blockData } = useBlockQuery(+teamId, selectedBlock?.timeBlockId ?? 0);
   const { data: documentData } = useTotalDocumentQuery(+teamId, 'executive', selectedId);
 
   return (

--- a/src/page/archiving/index/hook/api/useBlockQuery.ts
+++ b/src/page/archiving/index/hook/api/useBlockQuery.ts
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getDocuments } from '@/shared/api/time-blocks/team/time-block';
 
-export const useBlockQuery = (teamId: number, blockId: number, selectedId: string) => {
+export const useBlockQuery = (teamId: number, blockId: number) => {
   return useQuery({
     queryKey: ['document', blockId],
     queryFn: () => getDocuments(teamId, blockId),
-    enabled: selectedId === 'selected',
+    enabled: !!blockId,
   });
 };

--- a/src/page/landing/LandingPage.tsx
+++ b/src/page/landing/LandingPage.tsx
@@ -21,8 +21,8 @@ import Heading from '@/common/component/Heading/Heading';
 import Text from '@/common/component/Text/Text';
 import { useIntersectionObserver } from '@/common/hook/useObserver';
 
+import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
-import useStore from '@/shared/store/auth';
 
 const LandingPage = () => {
   const handleObserve = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
@@ -43,7 +43,7 @@ const LandingPage = () => {
   const { targetRef: feature1Ref } = useIntersectionObserver(handleObserve, option);
   const { targetRef: feature2Ref } = useIntersectionObserver(handleObserve, option);
 
-  const { isLoggedIn } = useStore();
+  const isAuth = !!localStorage.getItem(ACCESS_TOKEN_KEY);
 
   const 세번째뷰로 = () => {
     const next = feature1Ref.current;
@@ -55,7 +55,7 @@ const LandingPage = () => {
   };
 
   const 다음페이지로 = () => {
-    window.location.href = isLoggedIn ? PATH.SHOWCASE : PATH.LOGIN;
+    window.location.href = isAuth ? PATH.SHOWCASE : PATH.LOGIN;
   };
 
   return (

--- a/src/page/login/index/LoginPage.tsx
+++ b/src/page/login/index/LoginPage.tsx
@@ -2,7 +2,7 @@ import { findPasswordButtonStyle, formStyle, pageStyle } from '@/page/login/inde
 import { useLoginMutation } from '@/page/login/index/hook/useLoginMutation';
 
 import { FormEvent, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import Logo from '@/common/asset/svg/logo_tiki_md.svg?react';
 import Button from '@/common/component/Button/Button';
@@ -10,7 +10,6 @@ import Flex from '@/common/component/Flex/Flex';
 import Input from '@/common/component/Input/Input';
 
 import { PATH } from '@/shared/constant/path';
-import useStore from '@/shared/store/auth';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -20,10 +19,6 @@ const LoginPage = () => {
 
   const { mutate } = useLoginMutation();
 
-  const { isLoggedIn } = useStore();
-
-  if (isLoggedIn) return <Navigate to={PATH.SHOWCASE} />;
-
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -31,11 +26,11 @@ const LoginPage = () => {
   };
 
   const 회원가입페이지로이동 = () => {
-    navigate('/signup');
+    navigate(PATH.SIGNUP);
   };
 
   const 비밀번호찾기페이지로이동 = () => {
-    navigate('/password/auth');
+    navigate(PATH.PASSWORD_AUTH);
   };
 
   return (

--- a/src/shared/api/auth/reissue/index.ts
+++ b/src/shared/api/auth/reissue/index.ts
@@ -1,7 +1,7 @@
-import { axiosInstance } from '@/shared/api/instance';
+import axios from 'axios';
 
 export const getReissuedToken = async () => {
-  const response = await axiosInstance.get('/auth/reissue');
+  const response = await axios.get('/auth/reissue');
 
   return response.data;
 };

--- a/src/shared/api/auth/reissue/index.ts
+++ b/src/shared/api/auth/reissue/index.ts
@@ -1,7 +1,7 @@
-import axios from 'axios';
+import { axiosPublicInstance } from '@/shared/api/instance';
 
 export const getReissuedToken = async () => {
-  const response = await axios.get('/auth/reissue');
+  const response = await axiosPublicInstance.get('/auth/reissue');
 
   return response.data;
 };

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { checkAndUpateToken } from '@/shared/api/interceptor';
+import { handleCheckAndSetToken, handleTokenError } from '@/shared/api/interceptor';
 
 export const axiosInstance = axios.create({
   baseURL: `${import.meta.env.VITE_BASE_URL}/api/v1`,
@@ -13,10 +13,11 @@ export const axiosInstance = axios.create({
 
 export const axiosPublicInstance = axios.create({
   baseURL: `${import.meta.env.VITE_BASE_URL}/api/v1`,
-  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-axiosInstance.interceptors.request.use(checkAndUpateToken);
+axiosInstance.interceptors.request.use(handleCheckAndSetToken);
+
+axiosInstance.interceptors.response.use((res) => res, handleTokenError);

--- a/src/shared/api/interceptor.ts
+++ b/src/shared/api/interceptor.ts
@@ -36,7 +36,7 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
 
   const { status } = error.response;
 
-  if (status === HTTP_STATUS_CODE.UNAUTHORIZED) {
+  if (status === HTTP_STATUS_CODE.UNAUTHORIZED || status === HTTP_STATUS_CODE.NOT_FOUND) {
     const refreshToken = localStorage.getItem('refresh');
 
     if (!refreshToken) {

--- a/src/shared/api/interceptor.ts
+++ b/src/shared/api/interceptor.ts
@@ -1,9 +1,20 @@
-import { InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 
-import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
+import { axiosInstance } from '@/shared/api/instance';
+import { ACCESS_TOKEN_KEY, HTTP_STATUS_CODE } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
 
-export const checkAndUpateToken = (config: InternalAxiosRequestConfig) => {
+interface ErrorResponse {
+  success?: boolean;
+  message?: string;
+  code?: number;
+}
+
+type TokenResponse = {
+  accessToken: string;
+};
+
+export const handleCheckAndSetToken = (config: InternalAxiosRequestConfig) => {
   if (!config || !config.headers || config.headers.Authorization) return config;
 
   const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
@@ -16,4 +27,41 @@ export const checkAndUpateToken = (config: InternalAxiosRequestConfig) => {
   config.headers.Authorization = `Bearer ${accessToken}`;
 
   return config;
+};
+
+export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
+  const originRequest = error.config;
+
+  if (!error.response || !originRequest) throw new Error('에러가 발생했습니다.');
+
+  const { status } = error.response;
+
+  if (status === HTTP_STATUS_CODE.UNAUTHORIZED) {
+    const refreshToken = localStorage.getItem('refresh');
+
+    if (!refreshToken) {
+      window.location.href = PATH.ROOT;
+      throw new Error('리프레시 토큰이 존재하지 않습니다.');
+    }
+
+    try {
+      const { data } = await axios.get<TokenResponse>(`${import.meta.env.VITE_BASE_URL}/api/v1/auth/reissue`, {
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+      });
+
+      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
+      originRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+
+      return axiosInstance(originRequest);
+    } catch (error) {
+      localStorage.removeItem(ACCESS_TOKEN_KEY);
+      localStorage.removeItem('refresh');
+      window.location.href = PATH.ROOT;
+      throw new Error('토큰 갱신에 실패하였습니다.');
+    }
+  }
+
+  return Promise.reject(error);
 };

--- a/src/shared/api/interceptor.ts
+++ b/src/shared/api/interceptor.ts
@@ -11,7 +11,9 @@ interface ErrorResponse {
 }
 
 type TokenResponse = {
-  accessToken: string;
+  data: {
+    accessToken: string;
+  };
 };
 
 export const handleCheckAndSetToken = (config: InternalAxiosRequestConfig) => {
@@ -20,7 +22,7 @@ export const handleCheckAndSetToken = (config: InternalAxiosRequestConfig) => {
   const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
 
   if (!accessToken) {
-    window.location.href = PATH.ROOT;
+    window.location.replace(PATH.ROOT);
     throw new Error('토큰이 존재하지 않습니다.');
   }
 
@@ -40,7 +42,7 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
     const refreshToken = localStorage.getItem('refresh');
 
     if (!refreshToken) {
-      window.location.href = PATH.ROOT;
+      window.location.replace(PATH.ROOT);
       throw new Error('리프레시 토큰이 존재하지 않습니다.');
     }
 
@@ -51,14 +53,14 @@ export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
         },
       });
 
-      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
-      originRequest.headers.Authorization = `Bearer ${data.accessToken}`;
+      localStorage.setItem(ACCESS_TOKEN_KEY, data.data.accessToken);
+      originRequest.data.headers.Authorization = `Bearer ${data.data.accessToken}`;
 
       return axiosInstance(originRequest);
     } catch (error) {
       localStorage.removeItem(ACCESS_TOKEN_KEY);
       localStorage.removeItem('refresh');
-      window.location.href = PATH.ROOT;
+      window.location.replace(PATH.ROOT);
       throw new Error('토큰 갱신에 실패하였습니다.');
     }
   }

--- a/src/shared/component/LeftSidebar/LeftSidebar.style.ts
+++ b/src/shared/component/LeftSidebar/LeftSidebar.style.ts
@@ -4,14 +4,17 @@ import { theme } from '@/common/style/theme/theme';
 
 export const containerStyle = () =>
   css({
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+
     position: 'fixed',
     top: '0',
     left: '0',
-    zIndex: theme.zIndex.overlayHigh,
-
-    transformOrigin: 'left',
 
     height: '100vh',
+
+    zIndex: theme.zIndex.overlayHigh,
 
     padding: '2.4rem 2rem 2rem 0',
 
@@ -20,6 +23,7 @@ export const containerStyle = () =>
 
     boxShadow: '0px 2px 10px 0px rgba(0, 0, 0, 0.10)',
 
+    transformOrigin: 'left',
     transitionDuration: '0.5s',
   });
 
@@ -32,9 +36,11 @@ export const LogoSymbolStyle = css({
   height: '4rem',
 
   margin: '0 0 2.4rem 2rem',
-  borderRadius: '10px',
 
+  borderRadius: '10px',
   color: theme.colors.blue_900,
+
+  cursor: 'pointer',
 });
 
 export const leftSidebarListStyle = css({
@@ -54,9 +60,4 @@ export const arrowStyle = css({
   width: '1.2rem',
 
   cursor: 'pointer',
-});
-
-export const settingStyle = css({
-  position: 'absolute',
-  bottom: '2.4rem',
 });

--- a/src/shared/component/LeftSidebar/LeftSidebar.tsx
+++ b/src/shared/component/LeftSidebar/LeftSidebar.tsx
@@ -18,7 +18,6 @@ import {
   arrowStyle,
   containerStyle,
   leftSidebarListStyle,
-  settingStyle,
 } from '@/shared/component/LeftSidebar/LeftSidebar.style';
 import LeftSidebarItem from '@/shared/component/LeftSidebar/LeftSidebarItem/LeftSidebarItem';
 import SettingMenu from '@/shared/component/LeftSidebar/LeftSidebarItem/SettingMenu/SettingMenu';
@@ -125,9 +124,9 @@ const LeftSidebar = () => {
 
   return (
     <aside css={containerStyle} ref={sidebarRef}>
-      {isNavOpen ? <LeftArrow css={arrowStyle} onClick={close} /> : <RightArrow css={arrowStyle} onClick={open} />}
-      <LogoSymbol css={LogoSymbolStyle} />
       <nav>
+        {isNavOpen ? <LeftArrow css={arrowStyle} onClick={close} /> : <RightArrow css={arrowStyle} onClick={open} />}
+        <LogoSymbol css={LogoSymbolStyle} />
         <ul css={leftSidebarListStyle}>
           <LeftSidebarItem
             isClicked={clicked === 'showcase'}
@@ -160,7 +159,7 @@ const LeftSidebar = () => {
         </ul>
       </nav>
 
-      <div ref={settingRef} css={settingStyle}>
+      <div ref={settingRef}>
         <LeftSidebarItem
           isClicked={false}
           isExpansion={isNavOpen}

--- a/src/shared/component/Login/Login.tsx
+++ b/src/shared/component/Login/Login.tsx
@@ -1,30 +1,12 @@
 import { ReactNode, useEffect } from 'react';
 
-import { axiosInstance } from '@/shared/api/instance';
 import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
 import useStore from '@/shared/store/auth';
 
 const Login = ({ children }: { children: ReactNode }) => {
   const { login } = useStore();
 
-  /** 앱잼 서버 HTTP 배포로 인해 set-cookie를 통한 refresh token 쿠키에 저장 불가 */
-  const reissue = async () => {
-    /** 추후 수정 예정 */
-    const response = await axiosInstance.get('/auth/reissue', {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('refresh')}`,
-      },
-    });
-
-    const { accessToken } = response.data.data;
-
-    localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
-    axiosInstance.defaults.headers.Authorization = `Bearer ${accessToken}`;
-  };
-
   useEffect(() => {
-    reissue();
-
     if (localStorage.getItem(ACCESS_TOKEN_KEY)) {
       login();
     }


### PR DESCRIPTION
## 해당 이슈 번호

closed #181 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] ✨ 저는 (common/shared)로 분리했어요.

---
## 🤍 참고 사항

```ts
export const handleTokenError = async (error: AxiosError<ErrorResponse>) => {
  const originRequest = error.config;

  if (!error.response || !originRequest) throw new Error('에러가 발생했습니다.');

  const { status } = error.response;

  if (status === HTTP_STATUS_CODE.UNAUTHORIZED) {
    const refreshToken = localStorage.getItem('refresh');

    if (!refreshToken) {
      window.location.href = PATH.ROOT;
      throw new Error('리프레시 토큰이 존재하지 않습니다.');
    }

    try {
      const { data } = await axios.get<TokenResponse>(`${import.meta.env.VITE_BASE_URL}/api/v1/auth/reissue`, {
        headers: {
          Authorization: `Bearer ${refreshToken}`,
        },
      });

      localStorage.setItem(ACCESS_TOKEN_KEY, data.accessToken);
      originRequest.headers.Authorization = `Bearer ${data.accessToken}`;

      return axiosInstance(originRequest);
    } catch (error) {
      localStorage.removeItem(ACCESS_TOKEN_KEY);
      localStorage.removeItem('refresh');
      window.location.href = PATH.ROOT;
      throw new Error('토큰 갱신에 실패하였습니다.');
    }
  }

  return Promise.reject(error);
};
```

만약 API 요청에 대한 응답이 `401` 즉 액세스 토큰이 만료되었다고 뜨면, 리프레시 토큰과 함께 액세스 토큰 재발급 요청을 보내어 액세스 토큰을 갱신하는 로직입니다. 만약 재발급에 성공한다면, 액세스 토큰을 갱신한 후 이어서 요청을 보내고, 실패한다면 로컬 스토리지를 클리어하고 랜딩페이지로 이동합니다.

