### PR TITLE
[Refactor] Zustand Selector and Export Logic refactoring

### DIFF
--- a/src/common/component/Header/Header.tsx
+++ b/src/common/component/Header/Header.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import Logo from '@/common/asset/svg/logo_tiki_md.svg?react';
 
-import useStore from '@/shared/store/auth';
+import { useIsLoggedIn } from '@/shared/store/auth';
 
 import Button from '../Button/Button';
 import { headerStyle } from './Header.style';
@@ -10,7 +10,7 @@ import { headerStyle } from './Header.style';
 const Header = () => {
   const { pathname } = useLocation();
 
-  const isLogin = useStore((state) => state.isLoggedIn);
+  const isLoggedIn = useIsLoggedIn();
 
   const navigate = useNavigate();
 
@@ -29,7 +29,7 @@ const Header = () => {
     <header css={headerStyle}>
       <Logo onClick={() => navigate('/showcase')} />
       <div>
-        {isLogin ? (
+        {isLoggedIn ? (
           <Button variant="secondary" size="small">
             로그아웃
           </Button>

--- a/src/common/component/Modal/Modal.tsx
+++ b/src/common/component/Modal/Modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/no-static-element-interactions */
-
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
 /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -26,8 +24,10 @@ const Modal = ({ isOpen, children, onClose }: ModalProps) => {
 
   useEffect(() => {
     if (isOpen) {
+      const widthWithoutScrollbar = document.body.clientWidth;
+
       document.body.style.overflow = 'hidden';
-      document.body.style.maxWidth = `${document.body.clientWidth}px`;
+      document.body.style.maxWidth = `${widthWithoutScrollbar}px`;
       window.addEventListener('keydown', handleKeyDown);
     }
 
@@ -42,7 +42,7 @@ const Modal = ({ isOpen, children, onClose }: ModalProps) => {
     isOpen &&
     createPortal(
       <>
-        <div onClick={() => onClose?.()} css={backgroundStyle} />
+        <div aria-hidden={true} onClick={() => onClose?.()} css={backgroundStyle} />
         <dialog onClick={(e) => e.stopPropagation()} css={dialogStyle}>
           {children}
         </dialog>

--- a/src/common/component/ToastContainer/ToastProvider.tsx
+++ b/src/common/component/ToastContainer/ToastProvider.tsx
@@ -1,9 +1,12 @@
 import Toast from '@/common/component/Toast/Toast';
 
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction, useToastList } from '@/shared/store/toast';
 
 const ToastFactory = () => {
-  const { toastList, removeToast } = useToastStore();
+  const toastList = useToastList();
+
+  const { removeToast } = useToastAction();
+
   return (
     <>
       {toastList.map((toast) => (

--- a/src/page/archiving/createTimeBlock/component/Upload/UploadModal.tsx
+++ b/src/page/archiving/createTimeBlock/component/Upload/UploadModal.tsx
@@ -14,7 +14,7 @@ import Flex from '@/common/component/Flex/Flex';
 
 import { Files } from '@/shared/api/time-blocks/team/time-block/type';
 import WorkSapceInfo from '@/shared/component/createWorkSpace/info/WorkSpaceInfo';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 interface UploadModalProps {
   onClose: () => void;
@@ -31,7 +31,7 @@ const UploadModal = ({ onClose, teamId, type, blockData }: UploadModalProps) => 
 
   const { mutate: timeBlockMutate } = usePostTimeBlockMutation(teamId, type);
   const { mutate: fileDeleteMutate } = useDeleteFileMutation();
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
 
   useEffect(() => {
     const allUploaded =

--- a/src/page/archiving/index/ArchivingPage.tsx
+++ b/src/page/archiving/index/ArchivingPage.tsx
@@ -20,12 +20,12 @@ import Modal from '@/common/component/Modal/Modal';
 import { useModal, useOutsideClick } from '@/common/hook';
 import { theme } from '@/common/style/theme/theme';
 
-import { useTeamStore } from '@/shared/store/team';
+import { useTeamId } from '@/shared/store/team';
 
 const ArchivingPage = () => {
   const [selectedId, setSelectedId] = useState('total');
 
-  const { teamId } = useTeamStore();
+  const teamId = useTeamId();
 
   const handleClose = () => {
     selectedBlock && setSelectedBlock(undefined);

--- a/src/page/archiving/index/component/DocumentItem/DocumentItem.tsx
+++ b/src/page/archiving/index/component/DocumentItem/DocumentItem.tsx
@@ -16,7 +16,7 @@ import Text from '@/common/component/Text/Text';
 import { useModal } from '@/common/hook';
 
 import DeleteModal from '@/shared/component/DeleteModal/DeleteModal';
-import { useTeamStore } from '@/shared/store/team';
+import { useTeamId } from '@/shared/store/team';
 
 interface DocumentItemProps {
   documentId: number;
@@ -32,7 +32,7 @@ const DocumentItem = ({ documentId, children, selectedId, blockName, fileUrl, co
 
   const fileName = children?.toString();
 
-  const { teamId } = useTeamStore();
+  const teamId = useTeamId();
 
   //문서 클릭시 띄워주는 함수
   const onClickDocumentItem = () => {

--- a/src/page/archiving/index/component/SelectedBlock/SelectedBlock.tsx
+++ b/src/page/archiving/index/component/SelectedBlock/SelectedBlock.tsx
@@ -14,7 +14,7 @@ import { useModal } from '@/common/hook';
 import { theme } from '@/common/style/theme/theme';
 
 import DeleteModal from '@/shared/component/DeleteModal/DeleteModal';
-import { useTeamStore } from '@/shared/store/team';
+import { useTeamId } from '@/shared/store/team';
 
 import { blockNameStyle, deleteBtnStyle } from './SelectedBlock.style';
 
@@ -28,7 +28,7 @@ interface DocumentBarInfoProps {
 const SelectedBlock = ({ selectedId, blockName, selectedBlock, onClickClose }: DocumentBarInfoProps) => {
   const { isOpen, openModal, closeModal, currentContent } = useModal();
 
-  const { teamId } = useTeamStore();
+  const teamId = useTeamId();
 
   const { data: blockData } = useBlockQuery(+teamId, selectedBlock?.timeBlockId ?? 0);
 

--- a/src/page/archiving/index/component/TotalDocument/TotalDocument.tsx
+++ b/src/page/archiving/index/component/TotalDocument/TotalDocument.tsx
@@ -10,7 +10,7 @@ import Flex from '@/common/component/Flex/Flex';
 import Input from '@/common/component/Input/Input';
 import useDebounce from '@/common/hook/useDebounce';
 
-import { useTeamStore } from '@/shared/store/team';
+import { useTeamId } from '@/shared/store/team';
 
 interface DocumentBarToolProps {
   selectedId: string;
@@ -19,7 +19,7 @@ interface DocumentBarToolProps {
 const TotalDocument = ({ selectedId }: DocumentBarToolProps) => {
   const [selected, setSelected] = useState('최근 업로드 순');
 
-  const { teamId } = useTeamStore();
+  const teamId = useTeamId();
 
   const { data: documentDatas } = useTotalDocumentQuery(+teamId, 'executive');
 

--- a/src/page/login/index/hook/useLoginMutation.ts
+++ b/src/page/login/index/hook/useLoginMutation.ts
@@ -10,10 +10,10 @@ import { postSignIn } from '@/shared/api/auth/signin';
 import { axiosInstance } from '@/shared/api/instance';
 import { ACCESS_TOKEN_KEY, HTTP_STATUS_CODE } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 export const useLoginMutation = () => {
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
 
   const navigate = useNavigate();
 

--- a/src/page/login/password/auth/PasswordAuthPage.tsx
+++ b/src/page/login/password/auth/PasswordAuthPage.tsx
@@ -30,7 +30,7 @@ const PasswordAuthPage = () => {
   } = useTimer(EMAIL_REMAIN_TIME, SUPPORTING_TEXT.EMAIL_EXPIRED);
 
   const navigate = useNavigate();
-  const { resendMailMutation } = useResendMailMutation(email);
+  const { mutate: resendMailMutation } = useResendMailMutation(email);
   const { mutate, isError } = useVerifyCodeMutation(email, authCode);
 
   const handleMailSend = useCallback(() => {

--- a/src/page/login/password/auth/hook/useResendMailMutation.ts
+++ b/src/page/login/password/auth/hook/useResendMailMutation.ts
@@ -3,11 +3,12 @@ import { useMutation } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { reSendEmail } from '@/shared/api/mail/password';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 export const useResendMailMutation = (email: string) => {
-  const { createToast } = useToastStore();
-  const { mutate: resendMailMutation, isError: resendMailError } = useMutation({
+  const { createToast } = useToastAction();
+
+  const resendMailMutation = useMutation({
     mutationFn: () => reSendEmail(email),
     onSuccess: () => {
       createToast('메일을 성공적으로 전송했습니다.', 'success');
@@ -19,5 +20,5 @@ export const useResendMailMutation = (email: string) => {
     },
   });
 
-  return { resendMailMutation, resendMailError };
+  return resendMailMutation;
 };

--- a/src/page/login/password/reset/hook/useResetPasswordMutation.ts
+++ b/src/page/login/password/reset/hook/useResetPasswordMutation.ts
@@ -4,10 +4,11 @@ import { isAxiosError } from 'axios';
 
 import { resetPassword } from '@/shared/api/members/password';
 import { PasswordReset } from '@/shared/api/members/password/type';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 export const useResetPasswordMutation = () => {
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
+
   const resetPasswordMutation = useMutation({
     mutationFn: (data: PasswordReset) => resetPassword(data),
     onSuccess: () => {

--- a/src/page/signUp/index/TermPage.tsx
+++ b/src/page/signUp/index/TermPage.tsx
@@ -5,7 +5,7 @@ import { pageStyle } from '@/page/signUp/info/InfoFormPage.style';
 import { formStyle } from '@/page/signUp/info/component/InfoForm/InfoForm.style';
 
 import { useEffect, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import Button from '@/common/component/Button/Button';
 import Flex from '@/common/component/Flex/Flex';
@@ -14,7 +14,6 @@ import Text from '@/common/component/Text/Text';
 import { scrollStyle } from '@/common/style/theme/scroll';
 
 import { PATH } from '@/shared/constant/path';
-import useStore from '@/shared/store/auth';
 
 import { PERSONAL, TERM } from '@/mock/data/term';
 
@@ -39,9 +38,6 @@ const TermPage = () => {
       setTotalAgreeClicked(false);
     }
   }, [optionalTermsStatus, requiredTermsStatus, totalAgreeClicked]);
-
-  const { isLoggedIn } = useStore();
-  if (isLoggedIn) return <Navigate to={PATH.SHOWCASE} />;
 
   const 약관전체동의클릭 = () => {
     setTotalAgreeClicked((prev) => !prev);

--- a/src/page/signUp/info/component/InfoForm/InfoForm.tsx
+++ b/src/page/signUp/info/component/InfoForm/InfoForm.tsx
@@ -22,7 +22,7 @@ import { UserInfo } from '@/shared/api/signup/info/type';
 import { EMAIL_REMAIN_TIME, PLACEHOLDER, SUPPORTING_TEXT, UNIV_EMAIL_FORMAT } from '@/shared/constant/form';
 import { PATH } from '@/shared/constant/path';
 import { useVerifyCodeMutation } from '@/shared/hook/api/useVerifyCodeMutation';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 import { validateCode, validateEmail } from '@/shared/util/validate';
 
 interface InfoFormProps {
@@ -61,7 +61,7 @@ const InfoForm = ({ onInfoChange }: InfoFormProps) => {
 
   if (isVerified) onStop();
 
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
 
   const handleMailSend = () => {
     if (!UNIV_EMAIL_FORMAT.test(email)) {

--- a/src/page/signUp/info/hook/api/useSendMailMutation.ts
+++ b/src/page/signUp/info/hook/api/useSendMailMutation.ts
@@ -3,10 +3,10 @@ import { useMutation } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { postEmail } from '@/shared/api/mail/checking';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 export const useSendMailMutation = (email: string, onFail: () => void) => {
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
 
   const sendMailMutation = useMutation({
     mutationFn: () => postEmail(email),

--- a/src/page/signUp/info/hook/api/useSignupMutation.ts
+++ b/src/page/signUp/info/hook/api/useSignupMutation.ts
@@ -7,10 +7,10 @@ import { isAxiosError } from 'axios';
 import { postSignup } from '@/shared/api/signup/info';
 import { UserInfo } from '@/shared/api/signup/info/type';
 import { PATH } from '@/shared/constant/path';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 export const useSignupMutation = () => {
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
 
   const navigate = useNavigate();
 

--- a/src/shared/component/LeftSidebar/LeftSidebar.tsx
+++ b/src/shared/component/LeftSidebar/LeftSidebar.tsx
@@ -27,7 +27,7 @@ import WorkSpaceImage from '@/shared/component/createWorkSpace/image/WorkSpaceIm
 import WorkSpaceName from '@/shared/component/createWorkSpace/name/WorkSpaceName';
 import { PATH } from '@/shared/constant/path';
 import { useClubInfoQuery } from '@/shared/hook/api/useClubInfoQuery';
-import { useTeamStore } from '@/shared/store/team';
+import { useTeamIdAction } from '@/shared/store/team';
 import { Team } from '@/shared/type/team';
 
 import { usePostTeamMutation } from '../createWorkSpace/hook/api/usePostTeamMutation';
@@ -57,7 +57,7 @@ const LeftSidebar = () => {
 
   const { mutate: postTeamMutate } = usePostTeamMutation();
 
-  const { setTeamId } = useTeamStore();
+  const { setTeamId } = useTeamIdAction();
 
   useEffect(() => {
     const postData = {

--- a/src/shared/component/Login/Login.tsx
+++ b/src/shared/component/Login/Login.tsx
@@ -1,10 +1,10 @@
 import { ReactNode, useEffect } from 'react';
 
 import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
-import useStore from '@/shared/store/auth';
+import { useAuth } from '@/shared/store/auth';
 
 const Login = ({ children }: { children: ReactNode }) => {
-  const { login } = useStore();
+  const { login } = useAuth();
 
   useEffect(() => {
     if (localStorage.getItem(ACCESS_TOKEN_KEY)) {

--- a/src/shared/hook/api/useVerifyCodeMutation.ts
+++ b/src/shared/hook/api/useVerifyCodeMutation.ts
@@ -1,17 +1,20 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { checkAuthCode } from '@/shared/api/mail/signup';
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 export const useVerifyCodeMutation = (email: string, code: string) => {
-  const { createToast } = useToastStore();
+  const { createToast } = useToastAction();
 
   const verifyCodeMutation = useMutation({
     mutationKey: ['verifyCode', email, code],
+
     mutationFn: () => checkAuthCode(email, code),
+
     onSuccess: () => {
       createToast('인증이 완료되었습니다.', 'success');
     },
+
     onError: () => {
       createToast('인증번호가 일치하지 않습니다.', 'error');
     },

--- a/src/shared/hook/common/useLogout.ts
+++ b/src/shared/hook/common/useLogout.ts
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom';
 
 import { ACCESS_TOKEN_KEY } from '@/shared/constant/api';
 import { PATH } from '@/shared/constant/path';
-import useStore from '@/shared/store/auth';
+import { useAuth } from '@/shared/store/auth';
 
 export const useLogout = () => {
-  const { logout: onLogout } = useStore();
+  const { logout: onLogout } = useAuth();
 
   const navigate = useNavigate();
 

--- a/src/shared/store/auth.ts
+++ b/src/shared/store/auth.ts
@@ -2,15 +2,22 @@ import { create } from 'zustand';
 
 interface Store {
   isLoggedIn: boolean;
-  login: () => void;
-  logout: () => void;
+
+  actions: {
+    login: () => void;
+    logout: () => void;
+  };
 }
 
 const useStore = create<Store>((set) => ({
   isLoggedIn: false,
 
-  login: () => set({ isLoggedIn: true }),
-  logout: () => set({ isLoggedIn: false }),
+  actions: {
+    login: () => set({ isLoggedIn: true }),
+    logout: () => set({ isLoggedIn: false }),
+  },
 }));
 
-export default useStore;
+export const useIsLoggedIn = () => useStore((state) => state.isLoggedIn);
+
+export const useAuth = () => useStore((state) => state.actions);

--- a/src/shared/store/team.ts
+++ b/src/shared/store/team.ts
@@ -2,14 +2,22 @@ import { create } from 'zustand';
 
 type TeamStore = {
   teamId: string;
-  setTeamId: (id: string) => void;
+  actions: {
+    setTeamId: (id: string) => void;
+  };
 };
 
-export const useTeamStore = create<TeamStore>((set) => ({
+const useTeamStore = create<TeamStore>((set) => ({
   teamId: '0',
 
-  setTeamId: (id: string) =>
-    set({
-      teamId: id,
-    }),
+  actions: {
+    setTeamId: (teamId: string) =>
+      set({
+        teamId,
+      }),
+  },
 }));
+
+export const useTeamId = () => useTeamStore((state) => state.teamId);
+
+export const useTeamIdAction = () => useTeamStore((state) => state.actions);

--- a/src/shared/store/toast.ts
+++ b/src/shared/store/toast.ts
@@ -7,26 +7,34 @@ import { Toast } from '@/shared/type/toast';
 type ToastStore = {
   toastList: Toast[];
 
-  createToast: (message: string, variant?: Required<ToastProps>['variant']) => void;
-  removeToast: (id: number) => void;
+  actions: {
+    createToast: (message: string, variant?: Required<ToastProps>['variant']) => void;
+    removeToast: (id: number) => void;
+  };
 };
 
-export const useToastStore = create<ToastStore>((set) => ({
+const useToastStore = create<ToastStore>((set) => ({
   toastList: [],
 
-  createToast: (message: string, variant: Required<ToastProps>['variant'] = 'default') =>
-    set((state) => ({
-      toastList: [
-        ...state.toastList,
-        {
-          id: Number(Date.now()),
-          message,
-          variant,
-        },
-      ],
-    })),
-  removeToast: (id: number) =>
-    set((state) => ({
-      toastList: state.toastList.filter((item) => item.id !== id),
-    })),
+  actions: {
+    createToast: (message: string, variant: Required<ToastProps>['variant'] = 'default') =>
+      set((state) => ({
+        toastList: [
+          ...state.toastList,
+          {
+            id: Number(Date.now()),
+            message,
+            variant,
+          },
+        ],
+      })),
+    removeToast: (id: number) =>
+      set((state) => ({
+        toastList: state.toastList.filter((item) => item.id !== id),
+      })),
+  },
 }));
+
+export const useToastList = () => useToastStore((state) => state.toastList);
+
+export const useToastAction = () => useToastStore((state) => state.actions);

--- a/src/story/common/Toast.stories.tsx
+++ b/src/story/common/Toast.stories.tsx
@@ -4,7 +4,7 @@ import Toast from '@/common/component/Toast/Toast';
 import ToastContainer from '@/common/component/ToastContainer/ToastContainer';
 import ToastProvider from '@/common/component/ToastContainer/ToastProvider';
 
-import { useToastStore } from '@/shared/store/toast';
+import { useToastAction } from '@/shared/store/toast';
 
 const meta = {
   title: 'Common/Toast',
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => {
-    const { createToast } = useToastStore();
+    const { createToast } = useToastAction();
 
     return (
       <>
@@ -41,7 +41,7 @@ export const Default: Story = {
 
 export const Error: Story = {
   render: () => {
-    const { createToast } = useToastStore();
+    const { createToast } = useToastAction();
 
     return (
       <>
@@ -58,7 +58,7 @@ export const Error: Story = {
 
 export const Success: Story = {
   render: () => {
-    const { createToast } = useToastStore();
+    const { createToast } = useToastAction();
 
     return (
       <>


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 

---

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->

Zustand는 먼저 Redux와 같이 Flux 패턴을 기반으로, 중앙집중화된 Store 전략을 띄는 전역 상태 관리 라이브러리입니다.

이번에 저도 티키를 통해 `zustand`를 처음 써보면서, 아직은 서툴다는 것을 많이 느꼈는데, 최근에 제가 공유한 Zustand 관련 블로그들을 보면서 배우게 된 점과, 개선점 등을 말씀드릴려고 해용

1. 먼저 가장 흔하게 사용되는(공식문서에서도 제공하는) 사용법은 다음과 같습니다.

```js
const teamId = useTeamStore(state => state.teamId);
```

당연히 잘못된 코드는 아닙니다. 정상적으로 돌아가겠죠 ?
하지만 사용하는 소비자 입장에서 `selector`를 적용해주어야 합니다. 여기서 `selector`란 `state => state.teamId` 의 콜백함수를 넣어준 것을 볼 수 있다시피, 내가 구독하고 싶은 상태들만 뽑아내기 위해 적용하는 것을 말합니다.

따라서 구독한 상태의 값만을 편하게 사용하고 싶은 소비자 입장에서 일일히 `selector`를 설정해주는 것은 번거로운 일일 수도 있습니다.

2. 다음 사용법은 아래와 같습니다.

```js
const { teamId } = useTeamStore();
```

이번에는 전체 스토어를 구독해버렸습니다. 하지만 다음 코드는 사용하는 컴포넌트 입장에서 렌더링 측면에서 문제가 될 수도 있습니다. 왜냐하면 실제로 `teamId`가 바뀌지도 않았는데, 스토어 안의 다른 전역 상태가 변경된다면 해당 컴포넌트드는 다시 렌더링되기 떄문입니다.
또한 `Store` 안의 상태 업데이트 함수들은 다시 생성되기 때문에 이에 따라서도 다시 렌더링됩니다.

따라서 가장 효율적으로 Store를 구독하여 상태들을 사용하는 방법은 다음과 같습니다.

1. 아토믹한 `selector`를 사용하라
2. Store 전체를 `export`하는 것이 아니라, `selector`를 적용하여 내가 구독하고 싶은 상태만을 `export`하라.

1번은 `selector`를 적용할 떄, `===` 연산자로 연산이 가능한 값만을 아토믹 ! 하게 선택하라는 것입니다. 이 말은 즉슨, `selector`의 결과를 이전 렌더링의 결과와 엄격 동등 비교 (===) 하여 변경되었다면 리렌더링하는데, 객체나 배열을 반환하게 된다면 내용이 동일하다 하더라도 새롭게 렌더링하게 됩니다. 따라서 아토믹한 `selector`를 적용하라는 것이죠.

2번은 오로지 커스텀 훅만을 `export`하라는 말입니다. 즉 Store 보다는 아토믹한 셀렉터를 적용하여 반환된, 내가 구독하고 싶은 상태를 반환하는 커스텀 훅을 `export` 하라는 말입니다.

팀원분들도 제 pr 과, 제가 개선한 코드들을 보며 `zustand`에 대한 고찰을 해보셨으면 좋겠습니다 !

---

