### PR TITLE
[Feat] Carousel 합성 컴포넌트 구현

### DIFF
--- a/src/common/component/Carousel/Arrow.tsx
+++ b/src/common/component/Carousel/Arrow.tsx
@@ -1,0 +1,22 @@
+import LeftArrow from '@/common/asset/svg/arrow-left-white.svg?react';
+import RightArrow from '@/common/asset/svg/arrow-right-white.svg?react';
+import { arrowStyle } from '@/common/component/Carousel/Carousel.style';
+
+type ArrowProps = {
+  position: 'left' | 'right';
+  onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+const Arrow = ({ position, onClick }: ArrowProps) => {
+  return (
+    <button type="button" onClick={onClick} css={arrowStyle(position)}>
+      {position === 'left' ? (
+        <LeftArrow width="1.6rem" height="1.6rem" />
+      ) : (
+        <RightArrow width="1.6rem" height="1.6rem" />
+      )}
+    </button>
+  );
+};
+
+export default Arrow;

--- a/src/common/component/Carousel/Carousel.style.ts
+++ b/src/common/component/Carousel/Carousel.style.ts
@@ -6,14 +6,9 @@ import { theme } from '@/common/style/theme/theme';
 export const itemStyle = css({
   width: '100%',
 
-  fontSize: '32px',
-  color: 'white',
-
   flexShrink: 0,
 
-  backgroundColor: 'red',
-
-  '& > img': {
+  '& > *': {
     width: '100%',
     height: '100%',
     objectFit: 'cover',
@@ -45,6 +40,11 @@ export const containerStyle = ({ width, height }: Pick<CarouselProps, 'width' | 
     borderRadius: '16px',
 
     overflow: 'hidden',
+
+    '& *': {
+      userSelect: 'none',
+      touchAction: 'none',
+    },
   });
 
 export const arrowStyle = (position: 'left' | 'right') =>

--- a/src/common/component/Carousel/Carousel.style.ts
+++ b/src/common/component/Carousel/Carousel.style.ts
@@ -3,19 +3,21 @@ import { css } from '@emotion/react';
 import { CarouselProps } from '@/common/component/Carousel/Carousel';
 import { theme } from '@/common/style/theme/theme';
 
-export const itemStyle = css({
-  width: '100%',
-
-  flexShrink: 0,
-
-  position: 'relative',
-
-  '& > *': {
+export const itemStyle = (height: string) =>
+  css({
     width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-  },
-});
+    height,
+
+    flexShrink: 0,
+
+    position: 'relative',
+
+    '& > *': {
+      width: '100%',
+      height,
+      objectFit: 'cover',
+    },
+  });
 
 export const sliderStyle = (height: string) =>
   css({

--- a/src/common/component/Carousel/Carousel.style.ts
+++ b/src/common/component/Carousel/Carousel.style.ts
@@ -1,0 +1,75 @@
+import { css } from '@emotion/react';
+
+import { CarouselProps } from '@/common/component/Carousel/Carousel';
+import { theme } from '@/common/style/theme/theme';
+
+export const itemStyle = css({
+  width: '100%',
+
+  fontSize: '32px',
+  color: 'white',
+
+  flexShrink: 0,
+
+  backgroundColor: 'red',
+
+  '& > img': {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  },
+});
+
+export const sliderStyle = (height: string) =>
+  css({
+    display: 'flex',
+
+    width: '100%',
+    height,
+
+    overflow: 'hidden',
+
+    '& > div': {
+      width: '100%',
+      height,
+    },
+  });
+
+export const containerStyle = ({ width, height }: Pick<CarouselProps, 'width' | 'height'>) =>
+  css({
+    position: 'relative',
+
+    width,
+    height,
+
+    borderRadius: '16px',
+
+    overflow: 'hidden',
+  });
+
+export const arrowStyle = (position: 'left' | 'right') =>
+  css({
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: position === 'left' ? '1.6rem' : 'auto',
+    right: position === 'right' ? '1.6rem' : 'auto',
+
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+
+    margin: 'auto 0',
+
+    width: '3.2rem',
+    height: '3.2rem',
+
+    zIndex: theme.zIndex.overlayBottom,
+
+    border: 'none',
+    borderRadius: '16px',
+
+    background: 'rgb(0,0,0,0.3)',
+
+    cursor: 'pointer',
+  });

--- a/src/common/component/Carousel/Carousel.style.ts
+++ b/src/common/component/Carousel/Carousel.style.ts
@@ -8,6 +8,8 @@ export const itemStyle = css({
 
   flexShrink: 0,
 
+  position: 'relative',
+
   '& > *': {
     width: '100%',
     height: '100%',
@@ -69,7 +71,7 @@ export const arrowStyle = (position: 'left' | 'right') =>
     border: 'none',
     borderRadius: '16px',
 
-    background: 'rgb(0,0,0,0.3)',
+    background: 'rgb(255,255,255,0.3)',
 
     cursor: 'pointer',
   });

--- a/src/common/component/Carousel/Carousel.tsx
+++ b/src/common/component/Carousel/Carousel.tsx
@@ -1,4 +1,4 @@
-import { Children, MutableRefObject, PropsWithChildren, createContext, useRef, useState } from 'react';
+import React, { Children, MutableRefObject, PropsWithChildren, createContext, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 
 import Arrow from '@/common/component/Carousel/Arrow';
@@ -23,7 +23,7 @@ type CarouselContextType = {
 
 export const CarouselContext = createContext<CarouselContextType>({} as CarouselContextType);
 
-const Carousel = ({ width = '100vw', height = '300px', children, hasArrows = true, hasDots = true }: CarouselProps) => {
+const Carousel = ({ width = '100%', height = '400px', children, hasArrows = true, hasDots = true }: CarouselProps) => {
   const itemRef = useRef<HTMLDivElement | null>(null);
   const [currentIndex, setCurrentIndex] = useState(1);
 
@@ -31,6 +31,7 @@ const Carousel = ({ width = '100vw', height = '300px', children, hasArrows = tru
 
   const handleLeft = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+
     if (itemRef.current) {
       flushSync(() => {
         setCurrentIndex((prev) => (prev > 1 ? prev - 1 : 1));
@@ -42,9 +43,20 @@ const Carousel = ({ width = '100vw', height = '300px', children, hasArrows = tru
 
   const handleRight = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
+
     if (itemRef.current) {
       flushSync(() => {
         setCurrentIndex((prev) => (prev < length ? prev + 1 : length));
+      });
+
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  };
+
+  const handleMoveTo = (index: number) => {
+    if (itemRef.current) {
+      flushSync(() => {
+        setCurrentIndex(index);
       });
 
       itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
@@ -63,7 +75,7 @@ const Carousel = ({ width = '100vw', height = '300px', children, hasArrows = tru
 
         <div css={sliderStyle(height)}>{children}</div>
 
-        {hasDots && <Dots currentIdx={currentIndex} length={length} />}
+        {hasDots && <Dots moveToIndex={handleMoveTo} currentIdx={currentIndex} length={length} />}
       </div>
     </CarouselContext.Provider>
   );

--- a/src/common/component/Carousel/Carousel.tsx
+++ b/src/common/component/Carousel/Carousel.tsx
@@ -1,0 +1,74 @@
+import { Children, MutableRefObject, PropsWithChildren, createContext, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
+
+import Arrow from '@/common/component/Carousel/Arrow';
+import { containerStyle, sliderStyle } from '@/common/component/Carousel/Carousel.style';
+import CarouselItem from '@/common/component/Carousel/CarouselItem';
+import Dots from '@/common/component/Carousel/Dots';
+
+export interface CarouselProps extends PropsWithChildren {
+  width?: string;
+  height?: string;
+
+  hasArrows?: boolean;
+  hasDots?: boolean;
+
+  children: JSX.Element | JSX.Element[];
+}
+
+type CarouselContextType = {
+  currentIndex: number;
+  itemRef: MutableRefObject<HTMLDivElement | null>;
+};
+
+export const CarouselContext = createContext<CarouselContextType>({} as CarouselContextType);
+
+const Carousel = ({ width = '100vw', height = '300px', children, hasArrows = true, hasDots = true }: CarouselProps) => {
+  const itemRef = useRef<HTMLDivElement | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(1);
+
+  const length = Children.count(children);
+
+  const handleLeft = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (itemRef.current) {
+      flushSync(() => {
+        setCurrentIndex((prev) => (prev > 1 ? prev - 1 : 1));
+      });
+
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  };
+
+  const handleRight = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (itemRef.current) {
+      flushSync(() => {
+        setCurrentIndex((prev) => (prev < length ? prev + 1 : length));
+      });
+
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  };
+
+  return (
+    <CarouselContext.Provider value={{ currentIndex, itemRef }}>
+      <div css={containerStyle({ width, height })}>
+        {hasArrows && (
+          <>
+            <Arrow position="left" onClick={handleLeft} />
+            <Arrow position="right" onClick={handleRight} />
+          </>
+        )}
+
+        <div css={sliderStyle(height)}>{children}</div>
+
+        {hasDots && <Dots currentIdx={currentIndex} length={length} />}
+      </div>
+    </CarouselContext.Provider>
+  );
+};
+
+Carousel.Item = CarouselItem;
+
+export default Carousel;

--- a/src/common/component/Carousel/Carousel.tsx
+++ b/src/common/component/Carousel/Carousel.tsx
@@ -1,18 +1,10 @@
-import React, {
-  Children,
-  MutableRefObject,
-  PropsWithChildren,
-  createContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import { flushSync } from 'react-dom';
+import { Children, MutableRefObject, PropsWithChildren, createContext } from 'react';
 
 import Arrow from '@/common/component/Carousel/Arrow';
 import { containerStyle, sliderStyle } from '@/common/component/Carousel/Carousel.style';
 import CarouselItem from '@/common/component/Carousel/CarouselItem';
 import Dots from '@/common/component/Carousel/Dots';
+import { useCarousel } from '@/common/hook/useCarousel';
 
 export interface CarouselProps extends PropsWithChildren {
   width?: string;
@@ -28,6 +20,8 @@ export interface CarouselProps extends PropsWithChildren {
 }
 
 type CarouselContextType = {
+  width: string;
+  height: string;
   currentIndex: number;
   itemRef: MutableRefObject<HTMLDivElement | null>;
 };
@@ -43,81 +37,15 @@ const Carousel = ({
   hasArrows = true,
   hasDots = true,
 }: CarouselProps) => {
-  /**
-   * container hover 상태
-   * Item 요소 혹은 Arrow 에 마우스 hover 시 자동 Loop 중지
-   */
-  const [isContainerHover, setIsContainerHover] = useState(false);
-
-  /** 현재 view에 보여지고 있는 item ref */
-  const itemRef = useRef<HTMLDivElement | null>(null);
-  const [currentIndex, setCurrentIndex] = useState(1);
-
-  const length = Children.count(children);
-
-  /** 왼쪽 슬라이드로 */
-  const handleLeft = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-
-    if (itemRef.current) {
-      flushSync(() => {
-        setCurrentIndex((prev) => (prev > 1 ? prev - 1 : 1));
-      });
-
-      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
-    }
-  };
-
-  /** 오른쪽 슬라이드로 */
-  const handleRight = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-
-    if (itemRef.current) {
-      flushSync(() => {
-        setCurrentIndex((prev) => (prev < length ? prev + 1 : length));
-      });
-
-      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
-    }
-  };
-
-  /** Dot 클릭 시 해당 슬라이드로 */
-  const handleMoveTo = (index: number) => {
-    if (itemRef.current) {
-      flushSync(() => {
-        setCurrentIndex(index);
-      });
-
-      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
-    }
-  };
-
-  /** autoLoop: true 시 interval 생성 */
-  useEffect(() => {
-    if (autoLoop) {
-      const interval = setInterval(() => {
-        flushSync(() => {
-          setCurrentIndex((prev) => (prev < length ? prev + 1 : 1));
-        });
-
-        itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
-      }, autoLoopDelay);
-
-      /** Container hover 시 interval 종료 */
-      if (isContainerHover) {
-        clearInterval(interval);
-      }
-
-      return () => clearInterval(interval);
-    }
-  }, [autoLoop, length, isContainerHover]);
+  const { currentIndex, itemRef, handleLeft, handleRight, handleMoveTo, handleHover, handleLeave } = useCarousel(
+    Children.count(children),
+    autoLoop,
+    autoLoopDelay
+  );
 
   return (
-    <CarouselContext.Provider value={{ currentIndex, itemRef }}>
-      <div
-        onMouseOver={() => setIsContainerHover(true)}
-        onMouseLeave={() => setIsContainerHover(false)}
-        css={containerStyle({ width, height })}>
+    <CarouselContext.Provider value={{ width, height, currentIndex, itemRef }}>
+      <div onMouseOver={handleHover} onMouseLeave={handleLeave} css={containerStyle({ width, height })}>
         {hasArrows && (
           <>
             <Arrow position="left" onClick={handleLeft} />
@@ -127,7 +55,7 @@ const Carousel = ({
 
         <div css={sliderStyle(height)}>{children}</div>
 
-        {hasDots && <Dots moveToIndex={handleMoveTo} currentIdx={currentIndex} length={length} />}
+        {hasDots && <Dots moveToIndex={handleMoveTo} length={Children.count(children)} />}
       </div>
     </CarouselContext.Provider>
   );

--- a/src/common/component/Carousel/CarouselItem.tsx
+++ b/src/common/component/Carousel/CarouselItem.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren, useContext } from 'react';
+
+import { CarouselContext } from '@/common/component/Carousel/Carousel';
+import { itemStyle } from '@/common/component/Carousel/Carousel.style';
+
+type CarouselItemProps = PropsWithChildren<{ index: number }>;
+
+const CarouselItem = ({ index, children }: CarouselItemProps) => {
+  const { currentIndex, itemRef } = useContext(CarouselContext);
+
+  return (
+    <div
+      ref={(node) => {
+        if (currentIndex === index + 1) {
+          itemRef.current = node as HTMLDivElement;
+        }
+        return () => {
+          itemRef.current = null;
+        };
+      }}
+      css={itemStyle}>
+      {children}
+    </div>
+  );
+};
+
+export default CarouselItem;

--- a/src/common/component/Carousel/CarouselItem.tsx
+++ b/src/common/component/Carousel/CarouselItem.tsx
@@ -8,7 +8,7 @@ interface CarouselItemProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 const CarouselItem = ({ index, children, ...props }: CarouselItemProps) => {
-  const { currentIndex, itemRef } = useContext(CarouselContext);
+  const { height, currentIndex, itemRef } = useContext(CarouselContext);
 
   return (
     <div
@@ -17,7 +17,7 @@ const CarouselItem = ({ index, children, ...props }: CarouselItemProps) => {
           itemRef.current = node as HTMLDivElement;
         }
       }}
-      css={itemStyle}
+      css={itemStyle(height)}
       {...props}>
       <p css={{ position: 'absolute', top: '1.6rem', left: '1.6rem' }}>{index}</p>
       {children}

--- a/src/common/component/Carousel/CarouselItem.tsx
+++ b/src/common/component/Carousel/CarouselItem.tsx
@@ -1,11 +1,13 @@
-import { PropsWithChildren, useContext } from 'react';
+import { ComponentPropsWithoutRef, useContext } from 'react';
 
 import { CarouselContext } from '@/common/component/Carousel/Carousel';
 import { itemStyle } from '@/common/component/Carousel/Carousel.style';
 
-type CarouselItemProps = PropsWithChildren<{ index: number }>;
+interface CarouselItemProps extends ComponentPropsWithoutRef<'div'> {
+  index: number;
+}
 
-const CarouselItem = ({ index, children }: CarouselItemProps) => {
+const CarouselItem = ({ index, children, ...props }: CarouselItemProps) => {
   const { currentIndex, itemRef } = useContext(CarouselContext);
 
   return (
@@ -15,7 +17,9 @@ const CarouselItem = ({ index, children }: CarouselItemProps) => {
           itemRef.current = node as HTMLDivElement;
         }
       }}
-      css={itemStyle}>
+      css={itemStyle}
+      {...props}>
+      <p css={{ position: 'absolute', top: '1.6rem', left: '1.6rem' }}>{index}</p>
       {children}
     </div>
   );

--- a/src/common/component/Carousel/CarouselItem.tsx
+++ b/src/common/component/Carousel/CarouselItem.tsx
@@ -14,9 +14,6 @@ const CarouselItem = ({ index, children }: CarouselItemProps) => {
         if (currentIndex === index + 1) {
           itemRef.current = node as HTMLDivElement;
         }
-        return () => {
-          itemRef.current = null;
-        };
       }}
       css={itemStyle}>
       {children}

--- a/src/common/component/Carousel/Dots.tsx
+++ b/src/common/component/Carousel/Dots.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/react';
+
+interface DotsProps {
+  currentIdx: number;
+  length: number;
+}
+
+const Dots = ({ currentIdx, length }: DotsProps) => {
+  return (
+    <div css={dotContainerStyle}>
+      {Array.from({ length }).map((_, index) => (
+        <Dot key={index} isCurrent={index + 1 === currentIdx} />
+      ))}
+    </div>
+  );
+};
+
+export default Dots;
+
+type DotProps = {
+  isCurrent: boolean;
+};
+
+const Dot = ({ isCurrent }: DotProps) => {
+  return <div css={dotStyle(isCurrent)} />;
+};
+
+const dotContainerStyle = css`
+  display: flex;
+  gap: 0.8rem;
+
+  position: absolute;
+  bottom: 1.6rem;
+  left: 50%;
+
+  transform: translateX(-50%);
+`;
+
+const dotStyle = (isCurrent: boolean) =>
+  css({
+    width: '0.6rem',
+    height: '0.6rem',
+
+    opacity: isCurrent ? 0.8 : 0.3,
+
+    borderRadius: '50%',
+    backgroundColor: 'white',
+  });

--- a/src/common/component/Carousel/Dots.tsx
+++ b/src/common/component/Carousel/Dots.tsx
@@ -1,16 +1,21 @@
 import { css } from '@emotion/react';
 
+import { useContext } from 'react';
+
+import { CarouselContext } from '@/common/component/Carousel/Carousel';
+
 interface DotsProps {
-  currentIdx: number;
   length: number;
   moveToIndex?: (index: number) => void;
 }
 
-const Dots = ({ currentIdx, length, moveToIndex }: DotsProps) => {
+const Dots = ({ length, moveToIndex }: DotsProps) => {
+  const { currentIndex } = useContext(CarouselContext);
+
   return (
     <div css={dotContainerStyle}>
       {Array.from({ length }).map((_, index) => (
-        <Dot onClick={() => moveToIndex?.(index + 1)} key={index} isCurrent={index + 1 === currentIdx} />
+        <Dot isCurrent={currentIndex === index + 1} onClick={() => moveToIndex?.(index + 1)} key={index} />
       ))}
     </div>
   );
@@ -40,8 +45,8 @@ const dotContainerStyle = css`
 
 const dotStyle = (isCurrent: boolean) =>
   css({
-    width: '0.6rem',
-    height: '0.6rem',
+    width: '0.8rem',
+    height: '0.8rem',
 
     opacity: isCurrent ? 1 : 0.3,
 

--- a/src/common/component/Carousel/Dots.tsx
+++ b/src/common/component/Carousel/Dots.tsx
@@ -3,13 +3,14 @@ import { css } from '@emotion/react';
 interface DotsProps {
   currentIdx: number;
   length: number;
+  moveToIndex?: (index: number) => void;
 }
 
-const Dots = ({ currentIdx, length }: DotsProps) => {
+const Dots = ({ currentIdx, length, moveToIndex }: DotsProps) => {
   return (
     <div css={dotContainerStyle}>
       {Array.from({ length }).map((_, index) => (
-        <Dot key={index} isCurrent={index + 1 === currentIdx} />
+        <Dot onClick={() => moveToIndex?.(index + 1)} key={index} isCurrent={index + 1 === currentIdx} />
       ))}
     </div>
   );
@@ -19,10 +20,11 @@ export default Dots;
 
 type DotProps = {
   isCurrent: boolean;
+  onClick: () => void;
 };
 
-const Dot = ({ isCurrent }: DotProps) => {
-  return <div css={dotStyle(isCurrent)} />;
+const Dot = ({ onClick, isCurrent }: DotProps) => {
+  return <div onClick={onClick} css={dotStyle(isCurrent)} />;
 };
 
 const dotContainerStyle = css`
@@ -41,8 +43,10 @@ const dotStyle = (isCurrent: boolean) =>
     width: '0.6rem',
     height: '0.6rem',
 
-    opacity: isCurrent ? 0.8 : 0.3,
+    opacity: isCurrent ? 1 : 0.3,
 
     borderRadius: '50%',
     backgroundColor: 'white',
+
+    cursor: 'pointer',
   });

--- a/src/common/hook/useCarousel.ts
+++ b/src/common/hook/useCarousel.ts
@@ -1,0 +1,89 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
+
+export const useCarousel = (length: number, autoLoop?: boolean, autoLoopDelay?: number) => {
+  /**
+   * container hover 상태
+   * Item 요소 혹은 Arrow 에 마우스 hover 시 자동 Loop 중지
+   */
+  const [isContainerHover, setIsContainerHover] = useState(false);
+
+  /** 현재 view에 보여지고 있는 item ref */
+  const itemRef = useRef<HTMLDivElement | null>(null);
+  const [currentIndex, setCurrentIndex] = useState(1);
+
+  /** 왼쪽 슬라이드로 */
+  const handleLeft = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    if (itemRef.current) {
+      flushSync(() => {
+        setCurrentIndex((prev) => (prev > 1 ? prev - 1 : 1));
+      });
+
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  };
+
+  /** 오른쪽 슬라이드로 */
+  const handleRight = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+
+    if (itemRef.current) {
+      flushSync(() => {
+        setCurrentIndex((prev) => (prev < length ? prev + 1 : length));
+      });
+
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  };
+
+  /** Dot 클릭 시 해당 슬라이드로 */
+  const handleMoveTo = (index: number) => {
+    if (itemRef.current) {
+      flushSync(() => {
+        setCurrentIndex(index);
+      });
+
+      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  };
+
+  const handleHover = () => {
+    setIsContainerHover(true);
+  };
+
+  const handleLeave = () => {
+    setIsContainerHover(false);
+  };
+
+  /** autoLoop: true 시 interval 생성 */
+  useEffect(() => {
+    if (autoLoop) {
+      const interval = setInterval(() => {
+        flushSync(() => {
+          setCurrentIndex((prev) => (prev < length ? prev + 1 : 1));
+        });
+
+        itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+      }, autoLoopDelay);
+
+      /** Container hover 시 interval 종료 */
+      if (isContainerHover) {
+        clearInterval(interval);
+      }
+
+      return () => clearInterval(interval);
+    }
+  }, [autoLoop, length, isContainerHover]);
+
+  return {
+    currentIndex,
+    itemRef,
+    handleLeft,
+    handleRight,
+    handleMoveTo,
+    handleHover,
+    handleLeave,
+  };
+};

--- a/src/story/common/Carousel.stories.tsx
+++ b/src/story/common/Carousel.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import img1 from '@/common/asset/img/advBannerClub1.png';
+import img2 from '@/common/asset/img/advBannerClub2.png';
+import img3 from '@/common/asset/img/advBannerClub3.png';
+import Carousel from '@/common/component/Carousel/Carousel';
+
+const meta = {
+  title: 'Common/Carousel',
+  component: Carousel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Carousel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: [
+      <Carousel.Item index={0}>
+        <p css={{ position: 'absolute', color: 'white', top: '1.6rem', left: '1.6rem' }}>hihi</p>
+        <img src={img1} alt="img1" />
+      </Carousel.Item>,
+      <Carousel.Item index={1}>
+        <img src={img2} alt="img2" />
+      </Carousel.Item>,
+      <Carousel.Item index={2}>
+        <img src={img3} alt="img3" />
+      </Carousel.Item>,
+    ],
+  },
+
+  render: (args) => {
+    return <Carousel {...args} />;
+  },
+};

--- a/src/story/common/Carousel.stories.tsx
+++ b/src/story/common/Carousel.stories.tsx
@@ -16,12 +16,15 @@ const meta = {
     layout: 'centered',
   },
   tags: ['autodocs'],
+  args: {
+    children: [],
+  },
 } satisfies Meta<typeof Carousel>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const shadowStyle = css({
+const shadowStyle = css({
   '::before': {
     content: '""',
 
@@ -37,54 +40,27 @@ export const shadowStyle = css({
 });
 
 export const Default: Story = {
-  args: {
-    children: [
-      <Carousel.Item css={shadowStyle} key={0} index={0}>
-        <div style={{ position: 'absolute', top: '1.6rem', left: '1.6rem' }}>
-          <Heading css={{ color: 'white' }}>SOPT</Heading>
-          <Button css={{ width: '200px' }} variant="primary">
-            이동하기
-          </Button>
-        </div>
-        <img src={img1} alt="img1" />
-      </Carousel.Item>,
-      <Carousel.Item css={shadowStyle} key={1} index={1}>
-        <img src={img2} alt="img2" />
-      </Carousel.Item>,
-      <Carousel.Item key={2} index={2}>
-        <img src={img3} alt="img3" />
-      </Carousel.Item>,
-      <Carousel.Item key={3} index={3}>
-        <img src={img1} alt="img1" />
-      </Carousel.Item>,
-      <Carousel.Item key={4} index={4}>
-        <img src={img2} alt="img2" />
-      </Carousel.Item>,
-      <Carousel.Item key={5} index={5}>
-        <img src={img3} alt="img3" />
-      </Carousel.Item>,
-      <Carousel.Item key={6} index={6}>
-        <img src={img1} alt="img1" />
-      </Carousel.Item>,
-      <Carousel.Item key={7} index={7}>
-        <img src={img2} alt="img2" />
-      </Carousel.Item>,
-      <Carousel.Item key={8} index={8}>
-        <img src={img3} alt="img3" />
-      </Carousel.Item>,
-      <Carousel.Item key={9} index={9}>
-        <img src={img1} alt="img1" />
-      </Carousel.Item>,
-      <Carousel.Item key={10} index={10}>
-        <img src={img2} alt="img2" />
-      </Carousel.Item>,
-      <Carousel.Item key={11} index={11}>
-        <img src={img3} alt="img3" />
-      </Carousel.Item>,
-    ],
-  },
+  render: () => {
+    const arr = Array.from({ length: 10 }).map((_, i) => i + 1);
 
-  render: (args) => {
-    return <Carousel autoLoop={true} {...args} />;
+    return (
+      <Carousel autoLoop={true}>
+        {arr.map((num, idx) => (
+          <Carousel.Item css={shadowStyle} key={num} index={idx}>
+            <div css={{ position: 'absolute', padding: '3.2rem' }}>
+              <Heading css={{ color: 'white' }}>{num}번째 슬라이드</Heading>
+              <Button css={{ width: '200px' }} variant="primary">
+                이동하기
+              </Button>
+            </div>
+            <img
+              css={{ objectFit: 'cover' }}
+              src={idx % 3 === 0 ? img1 : idx % 3 === 1 ? img2 : img3}
+              alt={`img${num}`}
+            />
+          </Carousel.Item>
+        ))}
+      </Carousel>
+    );
   },
 };

--- a/src/story/common/Carousel.stories.tsx
+++ b/src/story/common/Carousel.stories.tsx
@@ -20,14 +20,42 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: [
-      <Carousel.Item index={0}>
+      <Carousel.Item key={0} index={0}>
         <p css={{ position: 'absolute', color: 'white', top: '1.6rem', left: '1.6rem' }}>hihi</p>
         <img src={img1} alt="img1" />
       </Carousel.Item>,
-      <Carousel.Item index={1}>
+      <Carousel.Item key={1} index={1}>
         <img src={img2} alt="img2" />
       </Carousel.Item>,
-      <Carousel.Item index={2}>
+      <Carousel.Item key={2} index={2}>
+        <img src={img3} alt="img3" />
+      </Carousel.Item>,
+      <Carousel.Item key={3} index={3}>
+        <img src={img1} alt="img1" />
+      </Carousel.Item>,
+      <Carousel.Item key={4} index={4}>
+        <img src={img2} alt="img2" />
+      </Carousel.Item>,
+      <Carousel.Item key={5} index={5}>
+        <img src={img3} alt="img3" />
+      </Carousel.Item>,
+      <Carousel.Item key={6} index={6}>
+        <p css={{ position: 'absolute', color: 'white', top: '1.6rem', left: '1.6rem' }}>hihi</p>
+        <img src={img1} alt="img1" />
+      </Carousel.Item>,
+      <Carousel.Item key={7} index={7}>
+        <img src={img2} alt="img2" />
+      </Carousel.Item>,
+      <Carousel.Item key={8} index={8}>
+        <img src={img3} alt="img3" />
+      </Carousel.Item>,
+      <Carousel.Item key={9} index={9}>
+        <img src={img1} alt="img1" />
+      </Carousel.Item>,
+      <Carousel.Item key={10} index={10}>
+        <img src={img2} alt="img2" />
+      </Carousel.Item>,
+      <Carousel.Item key={11} index={11}>
         <img src={img3} alt="img3" />
       </Carousel.Item>,
     ],

--- a/src/story/common/Carousel.stories.tsx
+++ b/src/story/common/Carousel.stories.tsx
@@ -1,9 +1,13 @@
+import { css } from '@emotion/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import img1 from '@/common/asset/img/advBannerClub1.png';
 import img2 from '@/common/asset/img/advBannerClub2.png';
 import img3 from '@/common/asset/img/advBannerClub3.png';
+import Button from '@/common/component/Button/Button';
 import Carousel from '@/common/component/Carousel/Carousel';
+import Heading from '@/common/component/Heading/Heading';
+import { theme } from '@/common/style/theme/theme';
 
 const meta = {
   title: 'Common/Carousel',
@@ -17,14 +21,34 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const shadowStyle = css({
+  '::before': {
+    content: '""',
+
+    position: 'absolute',
+    top: 0,
+    left: 0,
+
+    width: '16rem',
+    height: '100%',
+
+    background: theme.colors.black_shade,
+  },
+});
+
 export const Default: Story = {
   args: {
     children: [
-      <Carousel.Item key={0} index={0}>
-        <p css={{ position: 'absolute', color: 'white', top: '1.6rem', left: '1.6rem' }}>hihi</p>
+      <Carousel.Item css={shadowStyle} key={0} index={0}>
+        <div style={{ position: 'absolute', top: '1.6rem', left: '1.6rem' }}>
+          <Heading css={{ color: 'white' }}>SOPT</Heading>
+          <Button css={{ width: '200px' }} variant="primary">
+            이동하기
+          </Button>
+        </div>
         <img src={img1} alt="img1" />
       </Carousel.Item>,
-      <Carousel.Item key={1} index={1}>
+      <Carousel.Item css={shadowStyle} key={1} index={1}>
         <img src={img2} alt="img2" />
       </Carousel.Item>,
       <Carousel.Item key={2} index={2}>
@@ -40,7 +64,6 @@ export const Default: Story = {
         <img src={img3} alt="img3" />
       </Carousel.Item>,
       <Carousel.Item key={6} index={6}>
-        <p css={{ position: 'absolute', color: 'white', top: '1.6rem', left: '1.6rem' }}>hihi</p>
         <img src={img1} alt="img1" />
       </Carousel.Item>,
       <Carousel.Item key={7} index={7}>
@@ -62,6 +85,6 @@ export const Default: Story = {
   },
 
   render: (args) => {
-    return <Carousel {...args} />;
+    return <Carousel autoLoop={true} {...args} />;
   },
 };


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #230 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] ✨ 저는 `common/component/Carousel`로 분리했어요.

---

## 💎 PR Point

새롭게 알게 된 부분은 없지만, 기존에 많이 사용되는 타 slick 라이브러리와 "똑같이" 구현하기 위해서 많이 고민하고 적용해보고.. 하다가 실패했던 것도 많았네요. 그래도 나름 잘 구현했다고는 생각합니다 ! 

### Arrow 기능 구현하기

가장 먼저 구현한 것 중에 하나였어요. 다른 캐러셀 컴포넌트도 그러하듯이 양 옆에 화살표 버튼이 있고, 이걸 클릭시 이전/이후 슬라이드로 넘어가게 하도록 구현하였습니다. 가장 유용하게 활용했던 것은 `flushSync` 였어요.

```ts
 /** 왼쪽 슬라이드로 */
  const handleLeft = (e: React.MouseEvent<HTMLButtonElement>) => {
    e.stopPropagation();

    if (itemRef.current) {
      flushSync(() => {
        setCurrentIndex((prev) => (prev > 1 ? prev - 1 : 1));
      });

      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
    }
  };

  /** 오른쪽 슬라이드로 */
  const handleRight = (e: React.MouseEvent<HTMLButtonElement>) => {
    e.stopPropagation();

    if (itemRef.current) {
      flushSync(() => {
        setCurrentIndex((prev) => (prev < length ? prev + 1 : length));
      });

      itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
    }
  };
```

왼쪽 혹은 오른쪽 버튼을 누르면 위의 핸들러가 실행됩니다. `CarouselItem` 컴포넌트를 보면 알 수 있는데, 이 `currentIdx`란 상태가 바뀌면 해당 `Item` 컴포넌트에서 `itemRef`를 갈아끼워줘요. 즉, 현재 보여지는 슬라이드에 대한 `node` ref로 변경해줍니다. 따라서 `left` `right` 함수가 실행되면 `currentIndex` 상태를 `flushSync`로 동기적으로 바꿔주고 그에 대한 `ref`로 이동하게 됩니다.

`flushSync`를 사용하지 않게 되면 `state`는 비동기적으로 업데이트되는 특징이 있기 때문에 아직 상태가 업데이트되지 않은 상태에서 이전 `ref`를 기준으로 `scrollIntoView` 하게 되요.

그렇다면 `flushSync`를 굳이 써야되냐 ? 라고 성능적으로 물어본다면 써도 된다라고 생각하는 이유는, 이를 동기적으로 트리거하지 않는다면 `useEffect`가 필연적으로 들어가게 되요. 이벤트 핸들러로 처리해야 할/처리할 수 있는 로직은 해당 함수 안에서 작성하는 것 + 불필요한 `useEffect`를 지양하기 위함으로 `flushSync`를 사용하였습니다.

### `ref` callback

개념으로는 알고 있었지만 처음 코드로 구현해보는 녀석이였어요. `Item` 컴포넌트의 코드를 보면 다음과 같습니다.

```ts
const CarouselItem = ({ index, children, ...props }: CarouselItemProps) => {
  const { height, currentIndex, itemRef } = useContext(CarouselContext);

  return (
    <div
      ref={(node) => {
        if (currentIndex === index + 1) {
          itemRef.current = node as HTMLDivElement;
        }
      }}
      css={itemStyle(height)}
      {...props}>
      <p css={{ position: 'absolute', top: '1.6rem', left: '1.6rem' }}>{index}</p>
      {children}
    </div>
  );
};
```

여기서 `ref`에 들어가는 것이 콜백임을 확인할 수 있어요 ! `ref`에 콜백을 집어넣게 되면 인자로는 해당 노드에 대한 Element 정보를 얻을 수 있어요. 따라서 `Item` 컴포넌트는 리스트로 렌더링될 예정이기 때문에 모든 `ref` 를 하나씩 집어넣지는 못하고, 따라서 콜백을 사용함으로써 가각 렌더링되는 아이템 요소들마다 콜백으로 자신의 `node` 값을 알 수 있도록 처리했어요. 그 후 자신이 `currentIndex` 차례라면 해당 노드값을 `itemRef` 에 집어넣는 식으로 처리했습니다.

### 합성 ?

일단 합성 컴포넌트를 사용하여서 구현하였어요. 크게 `Carousel`, `CarouselItem`, `Dots`, `Dot` 4 개의 컴포넌트가 캐러셀이라는 컴포넌트 안에서 구현되게 되는데, 불필요한 `drilling`이 발생하는 것 같아서 해당 컴포넌트에 `Context`를 통해서 몇 가지 필요한 상태를 주입해주었습니다. 따라서 하위 컴포넌트에서는 `currentIndex`, `itemRef` 등의 필요한 값들을 `Context` 로부터 가져올 수 있게 됩니다.

### `autoLoop`, `autoLoopDelay`

기존 `react-slick` 과 같은 캐러셀 라이브러리 중에 대표적으로 쓰임새가 있다고 생각하는 속성들이라 이러한 속성도 제어할 수 있도록 구현해야겠다 싶어서 구현하였습니다. 당연히 `optional`이고 기본값은 `false`로 설정해두었습니다.

`delay` time 마다 슬라이드가 하나씩 넘어가야하기 때문에 `setInterval` API로 구현하였습니다.

```ts
/** autoLoop: true 시 interval 생성 */
  useEffect(() => {
    if (autoLoop) {
      const interval = setInterval(() => {
        flushSync(() => {
          setCurrentIndex((prev) => (prev < length ? prev + 1 : 1));
        });

        itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
      }, autoLoopDelay);

      /** Container hover 시 interval 종료 */
      if (isContainerHover) {
        clearInterval(interval);
      }

      return () => clearInterval(interval);
    }
  }, [autoLoop, length, isContainerHover]);
```

여기서 중요했던 포인트는 `isContainerHover`라는 상태였어요. 처음 이걸 구현할 때는 "아 자동으로 슬라이드가 넘어가는 타이밍에 화살표 버튼을 눌러서 한 번 더 넘어가면 UX가 별로다" 라고 생각해서 이를 막기 위해서 별 난리를 쳤는데 해당 상태 하나 추가해주니까 간결하게 해결되었습니다. 컨테이너(화살표 버튼 포함)위에 마우스가 있다면 캐러셀의 `loop`는 `false`이고 따라서 자동으로 넘어가지 않으니, 화살표 버튼을 눌러 이중으로 넘어가는 현상을 막을 수 있었습니다.

### 스토리북 Preview 로 테스트 해보시고 피드백 바랍니다

---

## 📌스크린샷 (선택)


https://github.com/user-attachments/assets/7ed464d2-5410-4956-af2e-8d60e7697888

