### PR TITLE
[Feat] Divider 공통 컴포넌트 구현

### DIFF
--- a/src/common/component/Divider/Divider.style.ts
+++ b/src/common/component/Divider/Divider.style.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+
+import { DividerProps } from '@/common/component/Divider/Divider';
+import { theme } from '@/common/style/theme/theme';
+
+export const commonStyle = css({
+  border: 'none',
+
+  backgroundColor: theme.colors.gray_200,
+});
+
+export const dividerStyle = (type: Required<DividerProps>['type'], size: number) => {
+  const style = {
+    horizontal: css({
+      width: `${size}rem`,
+      height: '0.1rem',
+    }),
+
+    vertical: css({
+      width: '0.1rem',
+      height: `${size}rem`,
+    }),
+  };
+
+  return style[type];
+};

--- a/src/common/component/Divider/Divider.tsx
+++ b/src/common/component/Divider/Divider.tsx
@@ -1,0 +1,14 @@
+import { HTMLAttributes } from 'react';
+
+import { commonStyle, dividerStyle } from '@/common/component/Divider/Divider.style';
+
+export interface DividerProps extends HTMLAttributes<HTMLHRElement> {
+  type?: 'horizontal' | 'vertical';
+  size?: number;
+}
+
+const Divider = ({ type = 'horizontal', size = 50 }: DividerProps) => {
+  return <hr css={[commonStyle, dividerStyle(type, size)]} />;
+};
+
+export default Divider;

--- a/src/common/component/Divider/Divider.tsx
+++ b/src/common/component/Divider/Divider.tsx
@@ -8,7 +8,7 @@ export interface DividerProps extends HTMLAttributes<HTMLHRElement> {
 }
 
 const Divider = ({ type = 'horizontal', size = 50 }: DividerProps) => {
-  return <hr css={[commonStyle, dividerStyle(type, size)]} />;
+  return <hr role="separator" css={[commonStyle, dividerStyle(type, size)]} />;
 };
 
 export default Divider;

--- a/src/story/common/Divider.stories.tsx
+++ b/src/story/common/Divider.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Divider from '@/common/component/Divider/Divider';
+
+const meta = {
+  title: 'Common/Divider',
+  component: Divider,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: { type: 'radio' },
+      options: ['horizontal', 'vertical'],
+    },
+    size: {
+      control: { type: 'number' },
+    },
+  },
+  args: {
+    type: 'horizontal',
+    size: 50,
+  },
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  args: {
+    type: 'horizontal',
+    size: 50,
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    type: 'vertical',
+    size: 3,
+  },
+};


### PR DESCRIPTION
<!-- [제목] title ex) feature/소셜 로그인 기능 추가 -->

## 해당 이슈 번호

closed #237 

---

## 체크리스트

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. [feat] PR을 등록한다.
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] ✅ 컨벤션을 지켰나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [ ] 💻 git rebase를 사용했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] ✨ 저는 common으로 분리했어요.

---

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적자 (기록하면서 개발하기!) -->
hr backgroundColor를 지정하는 과정에서 묘하게 이상하게 보여서 뭐지.. 했는데 디폴트로 border가 있더라고요.
`border: none`으로 주니 해결할 수 있었습니다.

---

현재는 vertical divider를 쓸 일이 없지만, 길이가 작든 크든 나중에 쓰일 경우가 생기지 않을까 생각해서 두 가지 타입(horizontal, vertical)으로 구현했습니다.
size의 경우 현재 뷰에 나와있는 경우에 따라 sm, md, lg 이런식으로 주려다가, vertical과 horizontal의 사이즈를 모두 따지기 힘들 것 같다고 판단해서 size라는 prop을 숫자로 넘겨주는 형태로 구현했습니다. (rem으로 단위 설정해줘서 그에 따라 넘겨주시면 됩니다.)

---

## 📌 질문할 부분 
---

## 📌스크린샷 (선택)

스토리북 preview로 확인해주시면 감사하겠습니당 !
